### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/extension/firefox/common.js
+++ b/extension/firefox/common.js
@@ -333,7 +333,7 @@ const ua = {
         const o = ua.object(null, windowId, tab.cookieStoreId);
         chrome.browserAction.setBadgeText({
           tabId,
-          text: o && o.platform ? o.platform.substr(0, 3) : ''
+          text: o && o.platform ? o.platform.slice(0, 3) : ''
         });
       }));
     }
@@ -341,7 +341,7 @@ const ua = {
       const o = ua.object(tabId, undefined, cookieStoreId);
       chrome.browserAction.setBadgeText({
         tabId,
-        text: o.platform ? o.platform.substr(0, 3) : 'BOT'
+        text: o.platform ? o.platform.slice(0, 3) : 'BOT'
       });
     }
   },


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.