### PR TITLE
Fix firefox/data/popup/browsers/ URL path broken after 2e4a330

### DIFF
--- a/v2/firefox/data/popup/index.js
+++ b/v2/firefox/data/popup/index.js
@@ -110,7 +110,7 @@ function get(path) {
       return cf;
     }
   }).open('agents').catch(() => cf).then(cache => {
-    const link = 'https://cdn.jsdelivr.net/gh/ray-lothian/UserAgent-Switcher/extension/firefox/data/popup/' + path;
+    const link = 'https://cdn.jsdelivr.net/gh/ray-lothian/UserAgent-Switcher/v2/firefox/data/popup/' + path;
     // updating agents once per 7 days
     chrome.storage.local.get({
       ['cache.' + path]: 0


### PR DESCRIPTION
Eg: https://cdn.jsdelivr.net/gh/ray-lothian/UserAgent-Switcher/v2/firefox/data/popup/browsers/chrome-windows.json
